### PR TITLE
[fix] 打印时将字体的颜色改为全黑

### DIFF
--- a/lapis.css
+++ b/lapis.css
@@ -232,6 +232,10 @@ mark {
         border-radius: 4px;
         margin-right: 3px;
     }
+
+    :root{
+        --text-color: rgb(0, 0, 0);
+    }
 }
 
 #write h1 {


### PR DESCRIPTION
打印时将字体的颜色改为全黑
作用：
1. 解决打印时字体发虚的问题
2. 加快浏览器对pdf文件的预览速度（当前使用了透明度，速度很慢）