### PR TITLE
Refactor the display of the background style of the h2 heading

### DIFF
--- a/lapis-dark.css
+++ b/lapis-dark.css
@@ -72,6 +72,9 @@
      color: var(--code-color);
  }
  
+ #write h2 code {
+    background-color: #303D51;
+ }
  /*
   * Image
   */

--- a/lapis-dark.css
+++ b/lapis-dark.css
@@ -57,24 +57,6 @@
  }
  
  /*
-  * Header
-  */
- 
- #write h2 span.md-plain {
-     background: var(--header-span-color);
-     color: var(--text-color);
- }
- 
- #write h2 span.md-link {
-     background: var(--header-span-color);
-     color: var(--text-color);
- }
- 
- #write h2.md-heading a {
-     border-bottom: 1px solid var(--text-color);
- }
- 
- /*
   * Quote
   */
  

--- a/lapis-dark.css
+++ b/lapis-dark.css
@@ -45,6 +45,13 @@
  content {
      background: var(--bg-color);
  }
+
+/*
+  * Header
+  */
+  #write h2 {
+    color: var(--text-color);
+}
  
  /*
   * Mark
@@ -73,7 +80,8 @@
  }
  
  #write h2 code {
-    background-color: #303D51;
+    background-color: var(--header-span-color);
+    color: var(--text-color);
  }
  /*
   * Image

--- a/lapis.css
+++ b/lapis.css
@@ -203,6 +203,10 @@ mark {
     border-bottom-color: #ffffff !important;
 }
 
+#write h2 strong {
+    color: #ffffff;
+}
+
 @media print {
     :root {
         --text-color: rgb(0, 0, 0);
@@ -239,7 +243,7 @@ mark {
 }
 
 #write h2 {
-    margin: 0em 0 0em;
+    margin: .3em 0;
 }
 
 #write h3 {

--- a/lapis.css
+++ b/lapis.css
@@ -191,6 +191,11 @@ mark {
     display: inline;
 }
 
+#write h2 a {
+    color: #ffffff;
+    border-bottom-color: #ffffff !important;
+}
+
 @media print {
     :root {
         --text-color: rgb(0, 0, 0);

--- a/lapis.css
+++ b/lapis.css
@@ -90,6 +90,13 @@
     margin: 2px;
 }
 
+#write h2.md-heading a {
+    text-decoration: underline;
+    border-bottom: 0;
+    text-decoration-thickness: 1.2px;
+    text-underline-offset: 2px;
+}
+
 [md-inline=url],
 [md-inline=link]>.md-content,
 [md-inline=image]>.md-meta {
@@ -186,7 +193,7 @@ mark {
 #write h2 {
     background-color: var(--header-span-color);
     color: #ffffff;
-    padding: 1px 10px;
+    padding: 1px 12.5px;
     border-radius: 4px;
     display: inline;
 }

--- a/lapis.css
+++ b/lapis.css
@@ -207,6 +207,11 @@ mark {
     color: #ffffff;
 }
 
+#write h2 code {
+    color: #ffffff;
+    background-color: #2F5B9B;
+}
+
 @media print {
     :root {
         --text-color: rgb(0, 0, 0);

--- a/lapis.css
+++ b/lapis.css
@@ -183,61 +183,15 @@ mark {
     text-align: center;
 }
 
-#write h2 span.md-plain {
-    background: var(--header-span-color);
-    padding: 1px 15px 2px;
+#write h2 {
+    background-color: var(--header-span-color);
+    color: #ffffff!important;
+    padding: 1px 10px;
     border-radius: 4px;
-    font-weight: bold;
-    color: #ffffff;
-}
-
-#write h2 span.md-link {
-    background: var(--header-span-color);
-    padding: 1px 11px 2px;
-    border-radius: 4px;
-    margin-left: -6px;
-    margin-right: -6px;
-}
-
-#write h2 span.md-link .md-plain {
-    background: #ffffff00;
-    padding: 1px 0px 3px;
-}
-
-#write h2 span.md-content {
-    color: #ffffff;
-}
-
-#write h2.md-heading a {
-    border-bottom: 1px solid white;
-}
-
-#write h2 span.md-inline-math {
-    background: var(--header-span-color);
-    padding: 1px 15px 1px;
-    border-radius: 4px;
-    font-weight: bold;
-    color: #ffffff;
-    line-height: 1.44;
-    margin-left: -6px;
-    margin-right: -6px;
-}
-
-#write h2 span.md-inline-math script {
-    color: #ffffff;
+    display: inline;
 }
 
 @media print {
-    #write h2 span {
-        display: inline-block;
-        font-weight: bold;
-        background: var(--primary-color);
-        color: #ffffff;
-        padding: 1px 15px 1px;
-        border-radius: 4px;
-        margin-right: 3px;
-    }
-
     :root {
         --text-color: rgb(0, 0, 0);
     }

--- a/lapis.css
+++ b/lapis.css
@@ -195,7 +195,7 @@ mark {
     color: #ffffff;
     padding: 1px 12.5px;
     border-radius: 4px;
-    display: inline;
+    display: inline-block;
 }
 
 #write h2 a {
@@ -239,7 +239,7 @@ mark {
 }
 
 #write h2 {
-    margin: 1.2em 0 1.2em;
+    margin: 0em 0 0em;
 }
 
 #write h3 {

--- a/lapis.css
+++ b/lapis.css
@@ -105,7 +105,7 @@
     font-family: 'JetBrainsMono';
     padding-left: 0.15rem;
     padding-right: 0rem;
-    color: #a2b6d4;
+    color: var(--marker-color);
 }
 
 
@@ -192,24 +192,24 @@ mark {
 
 #write h2 {
     background-color: var(--header-span-color);
-    color: #ffffff;
+    color: var(--bg-color);
     padding: 1px 12.5px;
     border-radius: 4px;
     display: inline-block;
 }
 
 #write h2 a {
-    color: #ffffff;
-    border-bottom-color: #ffffff !important;
+    color: var(--bg-color);
+    border-bottom-color: var(--bg-color) !important;
 }
 
 #write h2 strong {
-    color: #ffffff;
+    color: var(--bg-color);
 }
 
 #write h2 code {
-    color: #ffffff;
-    background-color: #2F5B9B;
+    color: var(--bg-color);
+    background-color: var(--header-span-color);
 }
 
 @media print {

--- a/lapis.css
+++ b/lapis.css
@@ -185,7 +185,7 @@ mark {
 
 #write h2 {
     background-color: var(--header-span-color);
-    color: #ffffff!important;
+    color: #ffffff;
     padding: 1px 10px;
     border-radius: 4px;
     display: inline;


### PR DESCRIPTION
# 重构h2标题的背景展示
当前存在几个小问题：

- [x] 链接的下划线过低的问题
- [x] 在light和dark下的行内代码的背景颜色与位置偏移问题
- [x] 链接在light下的文本颜色问题

现在先发起PR，先把这些问题在当前这个分支（h2-refactor）解决后再统一并入（因为上面的几个问题不先解决会导致体验更差）