### PR TITLE
Fix background color issue in file directory of Sitting - Unibody under dark mode

### DIFF
--- a/lapis.css
+++ b/lapis.css
@@ -805,3 +805,8 @@ header,
     background-color: var(--bg-color);
     background-image: none !important;
 }
+
+#recent-file-panel tbody tr:nth-child(2n-1) {
+    background-color: var(--recent-file-panel-n-bg-color);
+    color: var(--recent-file-panel-n-color);
+}


### PR DESCRIPTION
# Fix background color issue in file directory of Sitting - Unibody under dark mode
before:
![image](https://github.com/YiNNx/typora-theme-lapis/assets/37764175/9f498665-de69-41e4-ac5f-dd128b91953d)
after
![image](https://github.com/YiNNx/typora-theme-lapis/assets/37764175/d3eb283d-3b90-464b-b904-196d81e03150)

