### PR TITLE
Fix:Title identification overlaps with blockquote

### DIFF
--- a/lapis.css
+++ b/lapis.css
@@ -271,6 +271,13 @@ mark {
     margin: 0.4em 0 0.4em;
 }
 
+blockquote h3.md-focus:before,
+blockquote h4.md-focus:before,
+blockquote h5.md-focus:before,
+blockquote h6.md-focus:before {
+    left: -1.3rem; 
+}
+
 /*
  * List
  */


### PR DESCRIPTION
Fix: #52 
![image](https://github.com/YiNNx/typora-theme-lapis/assets/37764175/a054c375-fcec-41af-a701-36b1acd5dc62)
