### PR TITLE
Fix the issue of displaying scroll bars when exporting PDF

### DIFF
--- a/lapis.css
+++ b/lapis.css
@@ -30,6 +30,16 @@
     --active-file-bg-color: var(--block-bg-color);
 }
 
+@media print {
+    :root {
+        --text-color: rgb(0, 0, 0);
+    }
+
+    ::-webkit-scrollbar-thumb {
+        background-color: transparent !important;
+    }
+}
+
 /*
  * Font-face for Cantarell, Source Han Serif CN and JetBrains Mono
  */
@@ -214,12 +224,6 @@ mark {
 #write h2 code {
     color: var(--bg-color);
     background-color: var(--header-span-color);
-}
-
-@media print {
-    :root {
-        --text-color: rgb(0, 0, 0);
-    }
 }
 
 #write h1 {


### PR DESCRIPTION
原来导出的样式
![image](https://github.com/YiNNx/typora-theme-lapis/assets/37764175/a971093c-f1b5-4844-849e-a8703a50d1f4)
现在的导出样式
![image](https://github.com/YiNNx/typora-theme-lapis/assets/37764175/88e1120f-aa66-496d-908b-d9ca9997f582)

> 原来 `@media print` 的位置在下面，感觉不好，因此顺便把 `@media print` 那一串放在了 `:root` 和 `@font-face` 之间