### PR TITLE
Fix arrow alignment issue

### DIFF
--- a/lapis.css
+++ b/lapis.css
@@ -599,7 +599,10 @@ span.file-node-title-ext-part {
 
 .outline-item {
     padding-left: 2em;
-    padding-top: 0;
+}
+
+.outline-item>.outline-expander:before {
+    transform: translateY(-1px) !important;
 }
 
 /* Meta Block */


### PR DESCRIPTION
Fix #58 
![image](https://github.com/YiNNx/typora-theme-lapis/assets/37764175/d0b543a1-e4c1-4408-bdc1-589b268963b9)


> 同时修改了一下大纲中项目的padding，使得能够对齐
> ![image](https://github.com/YiNNx/typora-theme-lapis/assets/37764175/3cadd241-b68f-4a79-99b2-4e389d12af4d)
